### PR TITLE
Added a small example with js-to-c/c-to-js calls.

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all
+
+all:
+	../dist/bin/clang \
+		--target=wasm32-unknown-unknown-wasm \
+		--sysroot=../sysroot \
+		-g \
+		-O3 \
+		-o main.wasm \
+		-nostartfiles \
+		-Wl,--allow-undefined-file=main.syms,--import-memory,--import-table,--demangle,--no-entry,--no-threads \
+		-fvisibility=hidden \
+		main.c

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,3 +1,6 @@
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
 .PHONY: all
 
 all:

--- a/example/README.md
+++ b/example/README.md
@@ -23,3 +23,8 @@ Arguments used to build `main.wasm`:
 
 
 Run any small HTTP server (e.g. `python -m SimpleHTTPServer`).
+
+## License
+
+Any copyright is dedicated to the Public Domain.
+http://creativecommons.org/publicdomain/zero/1.0/

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,25 @@
+# About this example
+
+Build LLVM with experimental WASM target. Then run the Makefile: `make`.
+
+
+Arguments used to build `main.wasm`:
+
+  - `--target=wasm32-unknown-unknown-wasm`: tell to CLang we are building WASM bytecode
+  - `--sysroot=../sysroot`: gives the sysroot path (with libc + abi)
+  - (`-g`): debug symbols
+  - `-O3`: optimize, optimize, optimize !
+  - `-o main.wasm`: output file
+  - `-nostartfiles`: tell to CLang we don't have any `main` function
+  - `-fvisibility=hidden`: tell to CLang all symbols are hidden by default
+  - `-Wl`: pass to wasm linker the following arguments:
+    - `--allow-undefined-file=main.syms`: allow to "link" some undefined symbols, they will be imported from JS
+    - `--import-memory`: let us define the `WebAssembly.Memory` object from JS
+    - `--import-table`: we also want to define ourself the `WebAssembly.Table` object from JS
+    - (`--strip-all`): remove useless symbols
+    - (`--demangle`): useful if we build and export function in C++
+    - `--no-entry`: tell to the linker we don't have any entry point (`__start` function)
+    - (`--no-threads`): linking with thread support doesn't work well on every arch
+
+
+Run any small HTTP server (e.g. `python -m SimpleHTTPServer`).

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test</title>
+</head>
+<body>
+<script type="text/javascript">
+fetch('main.wasm').then(function(response) {
+    response.arrayBuffer().then(function(buffer) {
+        WebAssembly.compile(buffer).then(function(module) {
+
+            const memory = new WebAssembly.Memory({ initial: 32 });
+            const decoder = new TextDecoder("utf-8");
+            const imports = {
+                env: {
+                    memory: memory,
+                    __indirect_function_table: new WebAssembly.Table({ initial: 1, maximum: 1, element: 'anyfunc' }),
+                    __play_with_js: function() {
+                        return 42;
+                    },
+                    __console_log: function(str, len) {
+                        console.log(decoder.decode(memory.buffer.slice(str, str + len)));
+                    },
+                },
+            };
+
+            WebAssembly.instantiate(module, imports).then(function(instance) {
+                console.log(instance.exports.do_something(2));
+            });
+        });
+    });
+});
+</script>
+</body>
+</html>

--- a/example/index.html
+++ b/example/index.html
@@ -1,4 +1,8 @@
 <!DOCTYPE html>
+<!--
+Any copyright is dedicated to the Public Domain.
+http://creativecommons.org/publicdomain/zero/1.0/
+-->
 <html lang="en">
 <head>
     <meta charset="UTF-8">

--- a/example/main.c
+++ b/example/main.c
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 #include <string.h>
 
 /*

--- a/example/main.c
+++ b/example/main.c
@@ -1,0 +1,24 @@
+#include <string.h>
+
+/*
+ * Ask to JS about an integer
+ */
+int __play_with_js(void);
+
+/*
+ * Passing a string through linear memory and print it
+ */
+void __console_log(int str, int len);
+void console_log(char *str) {
+	__console_log((int) str, strlen(str));
+}
+
+/*
+ * Fn exported to JS
+ */
+__attribute__((visibility("default")))
+int do_something(int a) {
+	console_log("I'm speaking from WASM !");
+	return a + __play_with_js();
+}
+

--- a/example/main.syms
+++ b/example/main.syms
@@ -1,0 +1,2 @@
+__play_with_js
+__console_log


### PR DESCRIPTION
Please have a look to README.md to understand all CLang arguments.

@yurydelendik furthermore, in your basic test instead of using `_start` function you could use the same argument `-Wl,--no-entry` to tell wasm-ld we don't have any entry point.